### PR TITLE
requests 2.29+ compatibility

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,7 +4,6 @@ import pytest
 import json as _json
 import io
 
-from requests.adapters import HTTPResponse
 from requests import adapters
 
 

--- a/urlquick.py
+++ b/urlquick.py
@@ -60,7 +60,6 @@ except ImportError:
 # Third Party
 from htmlement import HTMLement
 from requests.structures import CaseInsensitiveDict
-from requests.adapters import HTTPResponse
 from requests import adapters
 from requests import *
 import requests


### PR DESCRIPTION
This commit removes HTTPResponse from `requests.adapters` https://github.com/psf/requests/commit/26bea1e498d6e234fbc9ce8e07c0389bac73810b

As kodi just released the addon requests 2.31, urlquick is broken and this fix seems to work with this last version.